### PR TITLE
[FIX]修正コミット　docker-compose.yml Volume記述変更、settings.py BASE_DIR修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build: 
       context: .
       dockerfile: Docker/mysql/Dockerfile
-    #Docker ボリューム mysql_data に /var/lib/mysql のデータが保存され、コンテナを削除してもデータが保持される
+    #Docker コンテナの管理する領域：ボリューム mysql_data に /var/lib/mysql のデータが保存され、コンテナを削除してもデータが保持される
     volumes: 
       - mysql_data:/var/lib/mysql
     environment:
@@ -34,11 +34,10 @@ services:
     build:
       context: .
       dockerfile: Docker/Django/Dockerfile
-     # volumes: ./src:/app/src
-    #  追加
-    volumes:
-      - ./remindapp:/app/remindapp # プロジェクト全体をマウント　→以前の記述- ./remindapp/templates:/app/remindapp/templates
-      #- ./remindapp/static:/app/remindapp/static 
+    # 現在のdocker-compose.ymlがあるディレクトリ配下の./remindappの中身を/appにマウントします。
+    # ⇒なので、ローカルの変更がそのままコンテナに反映されます。
+    volumes: 
+      - ./remindapp:/app
     ports: 
       - "8000:8000"
     depends_on:

--- a/remindapp/app/settings.py
+++ b/remindapp/app/settings.py
@@ -44,7 +44,7 @@ ROOT_URLCONF = 'app.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'remindapp/templates'],
+        'DIRS': [BASE_DIR / './templates'], #base_dir間違っているので修正
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -113,7 +113,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "remindapp", "static"),]
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"),] #修正
 
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 


### PR DESCRIPTION
〇docker-compose.ymlファイル：
・appコンテナ：volume　記述をバインドマウントに修正
・dbコンテナ：volume記述は、そのまま

〇settings.pyのディレクトリ構成：
・docker-compose.ymlの記述変更によりディレクトリ構成が変更されているため、BASE_DIRの記述とstaticのフォルダの記述を変更。